### PR TITLE
Loosen requirements

### DIFF
--- a/pvnet_summation/models/base_model.py
+++ b/pvnet_summation/models/base_model.py
@@ -65,22 +65,23 @@ class BaseModel(PVNetBaseModel):
         self.output_quantiles = output_quantiles
 
         # Number of timestemps for 30 minutely data
-        self.forecast_len_30 = self.forecast_minutes // 30
+        self.forecast_len = self.forecast_minutes // 30
 
-        self.weighted_losses = WeightedLosses(forecast_length=self.forecast_len_30)
+        self.weighted_losses = WeightedLosses(forecast_length=self.forecast_len)
 
         self._accumulated_metrics = MetricAccumulator()
         self._accumulated_y = PredAccumulator()
         self._accumulated_y_hat = PredAccumulator()
         self._accumulated_y_sum = PredAccumulator()
         self._accumulated_times = PredAccumulator()
+        self._horizon_maes = MetricAccumulator()
 
         self.use_quantile_regression = self.output_quantiles is not None
 
         if self.use_quantile_regression:
-            self.num_output_features = self.forecast_len_30 * len(self.output_quantiles)
+            self.num_output_features = self.forecast_len * len(self.output_quantiles)
         else:
-            self.num_output_features = self.forecast_len_30
+            self.num_output_features = self.forecast_len
 
         if self.pvnet_model.use_quantile_regression:
             self.pvnet_output_shape = (

--- a/pvnet_summation/models/model.py
+++ b/pvnet_summation/models/model.py
@@ -96,7 +96,7 @@ class Model(BaseModel):
 
         if self.use_quantile_regression:
             # Shape: batch_size, seq_length * num_quantiles
-            out = out.reshape(out.shape[0], self.forecast_len_30, len(self.output_quantiles))
+            out = out.reshape(out.shape[0], self.forecast_len, len(self.output_quantiles))
 
         if self.predict_difference_from_sum:
             gsp_sum = self.sum_of_gsps(x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ocf_datapipes==3.2.*
-pvnet==3.0.*
+ocf_datapipes>=3.2
+pvnet>=3.0
 numpy
 pandas
 matplotlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-ocf_datapipes>=3.2
-pvnet>=3.0
+ocf_datapipes>=3.3.19
+pvnet>=3.0.25
 numpy
 pandas
 matplotlib


### PR DESCRIPTION
Pinning requirements here makes it hard to update `pvnet_app` ([see for instance](https://github.com/openclimatefix/pvnet_app/actions/runs/8719387537/job/23918632203?pr=68)). I think it is better to loosen the requirements here and have them pinned in the app

I've also updated the package to be mostly compatible with the current PVNet, but it will need a proper digging through later - issue #19