### PR TITLE
Fix test config

### DIFF
--- a/tests/test_data/data_config.yaml
+++ b/tests/test_data/data_config.yaml
@@ -48,5 +48,5 @@ input_data:
 
   solar_position:
     interval_start_minutes: -60
-    interval_end_minutes: 480
+    interval_end_minutes: 120
     time_resolution_minutes: 30

--- a/tests/test_data/data_config.yaml
+++ b/tests/test_data/data_config.yaml
@@ -45,3 +45,8 @@ input_data:
       IR_016:
         mean: 0.17594202
         std: 0.21462157
+
+  solar_position:
+    interval_start_minutes: -60
+    interval_end_minutes: 480
+    time_resolution_minutes: 30

--- a/tests/test_data/data_config.yaml
+++ b/tests/test_data/data_config.yaml
@@ -8,7 +8,7 @@ input_data:
     interval_start_minutes: -60
     interval_end_minutes: 120
     time_resolution_minutes: 30
-    dropout_timedeltas_minutes: null
+    dropout_timedeltas_minutes: []
     dropout_fraction: 0
 
   nwp:
@@ -25,6 +25,10 @@ input_data:
       dropout_timedeltas_minutes: [-180]
       dropout_fraction: 1.0
       max_staleness_minutes: null
+      normalisation_constants:
+        t:
+          mean: 283.64913206
+          std: 4.38818501
 
   satellite:
     zarr_path: set_in_temp_file
@@ -35,5 +39,9 @@ input_data:
       - IR_016
     image_size_pixels_height: 4
     image_size_pixels_width: 4
-    dropout_timedeltas_minutes: null
+    dropout_timedeltas_minutes: []
     dropout_fraction: 0
+    normalisation_constants:
+      IR_016:
+        mean: 0.17594202
+        std: 0.21462157


### PR DESCRIPTION
We've had breaking changes in ocf-data-sampler Config model (normalisation constants, setting timedeltas to `[]` instead of `null`, defining solar position in config), so now the tests here trip up on config validation. This PR fixes it.