### PR TITLE
Minor speed up and data sampler compatibility fix

### DIFF
--- a/pvnet_summation/data/datamodule.py
+++ b/pvnet_summation/data/datamodule.py
@@ -72,19 +72,16 @@ class StreamedDataset(PVNetConcurrentDataset):
     def __init__(
         self,
         config_filename: str,
-        start_time: str | None = None,
-        end_time: str | None = None,
+        time_periods: list[tuple[str | None, str | None]] | None = None,
     ) -> None:
         """A torch dataset for creating concurrent PVNet inputs and national targets.
 
         Args:
             config_filename: Path to the configuration file
-            start_time: Limit the init-times to be after this
-            end_time: Limit the init-times to be before this
+            time_periods: List of (start, end) time period tuples to filter init-times
         """
-        time_periods = [(start_time, end_time)] if start_time or end_time else None
         super().__init__(config_filename, time_periods=time_periods)
-        
+
         self.national_data = (
             open_generation(
                 zarr_path=self.config.input_data.generation.zarr_path,
@@ -147,8 +144,8 @@ class StreamedDataModule(LightningDataModule):
     def __init__(
         self,
         configuration: str,
-        train_period: list[str | None] = [None, None],
-        val_period: list[str | None] = [None, None],
+        train_period: list[tuple[str | None, str | None]] | None = None,
+        val_period: list[tuple[str | None, str | None]] | None = None,
         num_workers: int = 0,
         prefetch_factor: int | None = None,
         persistent_workers: bool = False,
@@ -159,8 +156,8 @@ class StreamedDataModule(LightningDataModule):
 
         Args:
             configuration: Path to ocf-data-sampler configuration file.
-            train_period: Date range filter for train dataloader.
-            val_period: Date range filter for val dataloader.
+            train_period: Time period filters for train dataloader as list of (start, end) tuples.
+            val_period: Time period filters for val dataloader as list of (start, end) tuples.
             num_workers: Number of workers to use in multiprocess batch loading.
             prefetch_factor: Number of data will be prefetched at the end of each worker process.
             persistent_workers: If True, the data loader will not shut down the worker processes
@@ -214,10 +211,10 @@ class StreamedDataModule(LightningDataModule):
                     )
 
         # Prepare the train dataset
-        self.train_dataset = StreamedDataset(self.configuration, *self.train_period)
+        self.train_dataset = StreamedDataset(self.configuration, time_periods=self.train_period)
 
         # Prepare and pre-shuffle the val dataset and set seed for reproducibility
-        val_dataset = StreamedDataset(self.configuration, *self.val_period)
+        val_dataset = StreamedDataset(self.configuration, time_periods=self.val_period)
         shuffled_indices = np.random.default_rng(seed=self.seed).permutation(len(val_dataset))
         self.val_dataset = Subset(val_dataset, shuffled_indices)
 

--- a/pvnet_summation/data/datamodule.py
+++ b/pvnet_summation/data/datamodule.py
@@ -82,8 +82,9 @@ class StreamedDataset(PVNetConcurrentDataset):
             start_time: Limit the init-times to be after this
             end_time: Limit the init-times to be before this
         """
-        super().__init__(config_filename, start_time, end_time)
-
+        time_periods = [(start_time, end_time)] if start_time or end_time else None
+        super().__init__(config_filename, time_periods=time_periods)
+        
         self.national_data = (
             open_generation(
                 zarr_path=self.config.input_data.generation.zarr_path,

--- a/run.py
+++ b/run.py
@@ -16,6 +16,7 @@ from pvnet_summation.utils import maybe_apply_debug_mode, print_config
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
+# Use TF32 tensor cores for float32 matmul - approx 2.5 times faster on A6000.
 torch.set_float32_matmul_precision('medium')
 
 @hydra.main(config_path="configs/", config_name="config.yaml", version_base="1.2")

--- a/run.py
+++ b/run.py
@@ -8,6 +8,7 @@ import logging
 import sys
 
 import hydra
+import torch
 from omegaconf import DictConfig
 
 from pvnet_summation.training import train
@@ -15,7 +16,7 @@ from pvnet_summation.utils import maybe_apply_debug_mode, print_config
 
 logging.basicConfig(stream=sys.stdout, level=logging.ERROR)
 
-
+torch.set_float32_matmul_precision('medium')
 
 @hydra.main(config_path="configs/", config_name="config.yaml", version_base="1.2")
 def main(config: DictConfig) -> None:


### PR DESCRIPTION
Two small changes.

One liner to stop Tensor Core warning and actually use them - inspected matrix multiplication on the A6000: without, 7.11 ms and with, 2.88 ms. Approx 2.5 times faster and potentially 10-30% faster training for larger models? No effect on older GPUs either.

StreamedDataset updated to work with ocf-data-sampler>=1.0.0. CI was broken on main, just hadn't been triggered for a month or so.